### PR TITLE
Correct CMD builds & CMD checks errors

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,3 +2,4 @@
 ^cran-comments.md$
 ^\.travis\.yml$
 ^CRAN-RELEASE$
+^\.github$

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,0 +1,51 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+name: R-CMD-check.yaml
+
+permissions: read-all
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: macos-latest,   r: 'release'}
+          - {os: windows-latest, r: 'release'}
+          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-latest,   r: 'oldrel-1'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/.github/workflows/render-vignette-yaml.yml
+++ b/.github/workflows/render-vignette-yaml.yml
@@ -1,0 +1,25 @@
+on:
+  push:
+    branches:
+      - main
+name: vignettes
+jobs:
+  vignette:
+    name: Render-Vignette
+    runs-on: ubuntu-latest
+    container:
+      image: rocker/tidyverse
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install R dependencies
+        run: Rscript -e 'install.packages(c("DEoptimR","mathjaxr"))'
+      - name: Render Vignette
+        run: Rscript -e 'rmarkdown::render("vignette/guide.Rmd", output_dir = "vignette_output")'
+      - name: Deploy to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: vignette_output
+          CLEAN: true
+

--- a/R/functions.R
+++ b/R/functions.R
@@ -531,8 +531,9 @@ phaseModel <- function(data, calcurve, prior.matrix, model, plot=FALSE){
 
 	# plotting if required
 	if(plot & cond){
-		par(mfrow=c(1,3))
+		par(mfrow=c(2,2))
 		plotPD(PD)
+		image(prior.matrix,x=as.numeric(row.names(prior.matrix)), y=as.numeric(colnames(prior.matrix)),xlab=par.names[1],ylab=par.names[2], main='Joint prior parameters')
 		image(posterior,x=as.numeric(row.names(posterior)), y=as.numeric(colnames(posterior)),xlab=par.names[1],ylab=par.names[2], main='Joint posterior parameters')
 		points(x=map.p1, y=map.p2, pch=16, cex=2)
 		abline(v=map.p1)
@@ -540,7 +541,7 @@ phaseModel <- function(data, calcurve, prior.matrix, model, plot=FALSE){
 		years <- as.numeric(row.names(PD))
 		if(model=='norm')mod <- dnorm(years, map.p1, map.p2)
 		if(model=='ellipse')mod <- dellipse(years, map.p1, map.p2)
-		plot(years, mod*inc, xlab='calBP',ylab='PD', type='l',lwd=2, bty='n', xlim=rev(range(years)),ylim=c(0,max(mod)*inc),main=paste('Phase model using weighted mean posteriors:',par.names[1],'=',map.p1, par.names[2],'=',map.p2))
+		plot(years, mod*inc, xlab='calBP',ylab='PD', type='l',lwd=2, bty='n', xlim=rev(range(years)),ylim=c(0,max(mod)*inc),main=paste('Phase model:',par.names[1],'=',map.p1, par.names[2],'=',map.p2))
 		}
 return(res)}
 #--------------------------------------------------------------------------------------------

--- a/R/functions.R
+++ b/R/functions.R
@@ -520,18 +520,9 @@ phaseModel <- function(data, calcurve, prior.matrix, model, plot=FALSE){
 	tmp <- exp(log.posterior - const)
 	posterior <- tmp/sum(tmp)
 
-	# Maximum a posteriori (MAP)
-	# Deal with bizarre cases where there isnt a unique solution, e.g. uniform prior with no data??
-	max.mat <- posterior==max(posterior)
-	if(sum(max.mat)==1){
-		map.p1 <- round(as.numeric(names(which(rowSums(max.mat)==1))))
-		map.p2 <- round(as.numeric(names(which(colSums(max.mat)==1))))
-		}
-	if(sum(max.mat)!=1){
-		map.p1 <- round(sum(p1 * rowSums(posterior)))
-		map.p2 <- round(sum(p2 * colSums(posterior)))
-		warning('no unique solution for MAP, weighted mean returned!')
-		}
+	# Point estimates. Maximum a posteriori (MAP) is bad, as it will underestimate sigma for small N. Use weighted mean.
+	map.p1 <- round(sum(p1 * rowSums(posterior)))
+	map.p2 <- round(sum(p2 * colSums(posterior)))
 
 	# return the full posterior, the calibrated dates, and useful summary stats
 	res <- list(PD=PD, posterior=posterior, map.p1=map.p1, map.p2=map.p2)

--- a/R/functions.R
+++ b/R/functions.R
@@ -842,7 +842,7 @@ estimateDataDomain <- function(data, calcurve){
 	max.year <- max(calcurve$cal[calcurve$min<min.c14 | calcurve$max<max.c14])
 
 
-return(c(min.year-50, max.year+50))}
+return(c(min.year-100, max.year+100))}
 #--------------------------------------------------------------------------------------------
 SPDsimulationTest <- function(data, calcurve, calrange, pars, type, inc=5, N=20000, timeseries=NULL){
 

--- a/R/functions.R
+++ b/R/functions.R
@@ -531,7 +531,7 @@ phaseModel <- function(data, calcurve, prior.matrix, model, plot=FALSE){
 
 	# plotting if required
 	if(plot & cond){
-		par(mfrow=c(3,2))
+		par(mfrow=c(2,3))
 		plotPD(PD)
 		image(prior.matrix,x=as.numeric(row.names(prior.matrix)), y=as.numeric(colnames(prior.matrix)),xlab=par.names[1],ylab=par.names[2], main='Joint prior parameters')
 		image(exp(loglik),x=as.numeric(row.names(prior.matrix)), y=as.numeric(colnames(prior.matrix)),xlab=par.names[1],ylab=par.names[2], main='Likelihood')

--- a/R/functions.R
+++ b/R/functions.R
@@ -534,7 +534,7 @@ phaseModel <- function(data, calcurve, prior.matrix, model, plot=FALSE){
 		par(mfrow=c(3,2))
 		plotPD(PD)
 		image(prior.matrix,x=as.numeric(row.names(prior.matrix)), y=as.numeric(colnames(prior.matrix)),xlab=par.names[1],ylab=par.names[2], main='Joint prior parameters')
-		image(exp(loglik)),x=as.numeric(row.names(loglik)), y=as.numeric(colnames(loglik)),xlab=par.names[1],ylab=par.names[2], main='Likelihood')
+		image(exp(loglik),x=as.numeric(row.names(loglik)), y=as.numeric(colnames(loglik)),xlab=par.names[1],ylab=par.names[2], main='Likelihood')
 		image(posterior,x=as.numeric(row.names(posterior)), y=as.numeric(colnames(posterior)),xlab=par.names[1],ylab=par.names[2], main='Joint posterior parameters')
 		points(x=map.p1, y=map.p2, pch=16, cex=2)
 		abline(v=map.p1)

--- a/R/functions.R
+++ b/R/functions.R
@@ -531,9 +531,10 @@ phaseModel <- function(data, calcurve, prior.matrix, model, plot=FALSE){
 
 	# plotting if required
 	if(plot & cond){
-		par(mfrow=c(2,2))
+		par(mfrow=c(3,2))
 		plotPD(PD)
 		image(prior.matrix,x=as.numeric(row.names(prior.matrix)), y=as.numeric(colnames(prior.matrix)),xlab=par.names[1],ylab=par.names[2], main='Joint prior parameters')
+		image(exp(loglik)),x=as.numeric(row.names(loglik)), y=as.numeric(colnames(loglik)),xlab=par.names[1],ylab=par.names[2], main='Likelihood')
 		image(posterior,x=as.numeric(row.names(posterior)), y=as.numeric(colnames(posterior)),xlab=par.names[1],ylab=par.names[2], main='Joint posterior parameters')
 		points(x=map.p1, y=map.p2, pch=16, cex=2)
 		abline(v=map.p1)

--- a/R/functions.R
+++ b/R/functions.R
@@ -842,7 +842,7 @@ estimateDataDomain <- function(data, calcurve){
 	max.year <- max(calcurve$cal[calcurve$min<min.c14 | calcurve$max<max.c14])
 
 
-return(c(min.year, max.year))}
+return(c(min.year-50, max.year+50))}
 #--------------------------------------------------------------------------------------------
 SPDsimulationTest <- function(data, calcurve, calrange, pars, type, inc=5, N=20000, timeseries=NULL){
 

--- a/R/functions.R
+++ b/R/functions.R
@@ -534,7 +534,7 @@ phaseModel <- function(data, calcurve, prior.matrix, model, plot=FALSE){
 		par(mfrow=c(3,2))
 		plotPD(PD)
 		image(prior.matrix,x=as.numeric(row.names(prior.matrix)), y=as.numeric(colnames(prior.matrix)),xlab=par.names[1],ylab=par.names[2], main='Joint prior parameters')
-		image(exp(loglik),x=as.numeric(row.names(loglik)), y=as.numeric(colnames(loglik)),xlab=par.names[1],ylab=par.names[2], main='Likelihood')
+		image(exp(loglik),x=as.numeric(row.names(prior.matrix)), y=as.numeric(colnames(prior.matrix)),xlab=par.names[1],ylab=par.names[2], main='Likelihood')
 		image(posterior,x=as.numeric(row.names(posterior)), y=as.numeric(colnames(posterior)),xlab=par.names[1],ylab=par.names[2], main='Joint posterior parameters')
 		points(x=map.p1, y=map.p2, pch=16, cex=2)
 		abline(v=map.p1)

--- a/R/functions.R
+++ b/R/functions.R
@@ -5,6 +5,7 @@
 #--------------------------------------------------------------------------------------------	
 # global variables
 # if(getRversion() >= "2.15.1")  utils::globalVariables(c())
+intcal20 <- utils::globalVariables("intcal20")
 #--------------------------------------------------------------------------------------------
 getTruncatedModelChoices <- function(){
 	# Required in several functions, so avoids duplication if others are added to the package

--- a/R/functions.R
+++ b/R/functions.R
@@ -5,7 +5,7 @@
 #--------------------------------------------------------------------------------------------	
 # global variables
 # if(getRversion() >= "2.15.1")  utils::globalVariables(c())
-intcal20 <- utils::globalVariables("intcal20")
+utils::globalVariables("intcal20")
 #--------------------------------------------------------------------------------------------
 getTruncatedModelChoices <- function(){
 	# Required in several functions, so avoids duplication if others are added to the package

--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
-[![R-CMD-check](https://github.com/simoncarrignon/ADMUR/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/simoncarrignon/ADMUR/actions/workflows/R-CMD-check.yaml)
-
 <a href="https://github.com/UCL"><img src="tools/logos/logo_UCL.png" alt="UCL Research Software Development" height="70"/></a>
 <a href="https://www.ucl.ac.uk/biosciences/gee/molecular-and-cultural-evolution-lab"><img src="tools/logos/logo_MACElab.png" alt="UCL Research Software Development" height="70"/></a>
 <a href="https://www.shh.mpg.de"><img src="tools/logos/logo_MPI.png" alt="Max Planck Institute for the Science of Human History" height="70"/></a>
 <a href="https://www.shh.mpg.de/1143811/pan-ev"><img src="tools/logos/logo_PanEv.png" alt="Pan African Evolution ResearchGroup" height="70"/></a>
 
-
 # ADMUR
 ## Ancient Demographic Modelling Using Radiocarbon
 
+[![R-CMD-check](https://github.com/simoncarrignon/ADMUR/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/simoncarrignon/ADMUR/actions/workflows/R-CMD-check.yaml)
 
 Statistical tools to directly model underlying population dynamics using date datasets (radiocarbon and other). 
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 <a href="https://www.shh.mpg.de"><img src="tools/logos/logo_MPI.png" alt="Max Planck Institute for the Science of Human History" height="70"/></a>
 <a href="https://www.shh.mpg.de/1143811/pan-ev"><img src="tools/logos/logo_PanEv.png" alt="Pan African Evolution ResearchGroup" height="70"/></a>
 
-[![Build Status](https://app.travis-ci.com/AdrianTimpson/ADMUR.svg?branch=master)](https://app.travis-ci.com/AdrianTimpson/ADMUR)
+[![R-CMD-check](https://github.com/AdrianTimpson/ADMUR/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/AdrianTimpson/ADMUR/actions/workflows/R-CMD-check.yaml)
+
 
 # ADMUR
 ## Ancient Demographic Modelling Using Radiocarbon

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 <a href="https://www.shh.mpg.de"><img src="tools/logos/logo_MPI.png" alt="Max Planck Institute for the Science of Human History" height="70"/></a>
 <a href="https://www.shh.mpg.de/1143811/pan-ev"><img src="tools/logos/logo_PanEv.png" alt="Pan African Evolution ResearchGroup" height="70"/></a>
 
-[![R-CMD-check](https://github.com/AdrianTimpson/ADMUR/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/AdrianTimpson/ADMUR/actions/workflows/R-CMD-check.yaml)
-
 
 # ADMUR
 ## Ancient Demographic Modelling Using Radiocarbon
+
+[![R-CMD-check](https://github.com/AdrianTimpson/ADMUR/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/AdrianTimpson/ADMUR/actions/workflows/R-CMD-check.yaml)
 
 Statistical tools to directly model underlying population dynamics using date datasets (radiocarbon and other). 
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![R-CMD-check](https://github.com/simoncarrignon/ADMUR/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/simoncarrignon/ADMUR/actions/workflows/R-CMD-check.yaml)
+
 <a href="https://github.com/UCL"><img src="tools/logos/logo_UCL.png" alt="UCL Research Software Development" height="70"/></a>
 <a href="https://www.ucl.ac.uk/biosciences/gee/molecular-and-cultural-evolution-lab"><img src="tools/logos/logo_MACElab.png" alt="UCL Research Software Development" height="70"/></a>
 <a href="https://www.shh.mpg.de"><img src="tools/logos/logo_MPI.png" alt="Max Planck Institute for the Science of Human History" height="70"/></a>
@@ -7,7 +9,6 @@
 # ADMUR
 ## Ancient Demographic Modelling Using Radiocarbon
 
-[![R-CMD-check](https://github.com/AdrianTimpson/ADMUR/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/AdrianTimpson/ADMUR/actions/workflows/R-CMD-check.yaml)
 
 Statistical tools to directly model underlying population dynamics using date datasets (radiocarbon and other). 
 

--- a/man/SPDsimulationTest.Rd
+++ b/man/SPDsimulationTest.Rd
@@ -68,7 +68,7 @@
 	The default N = 20000 can be increased if greater precision is required, however this can be very time costly.
 	}
 \examples{
-\donttest{
+\dontrun{
 # trivial example showing a single date can never be rejected under a uniform model:
 data <- data.frame(age=6500, sd=50, phase=1, datingType='14C')
 x <- SPDsimulationTest(data, 

--- a/man/getPhaseModelChoices.Rd
+++ b/man/getPhaseModelChoices.Rd
@@ -4,7 +4,7 @@
 \description{
 	Lists currently available models for the PDF of an archaeological phase, the number of parameters, and a brief description
 	\loadmathjax }
-\usage{getTruncatedModelChoices()}
+\usage{getPhaseModelChoices()}
 
 \details{
 

--- a/man/intcal20.Rd
+++ b/man/intcal20.Rd
@@ -1,5 +1,5 @@
-\name{intcal20} 
 \docType{data}
+\name{intcal20} 
 \alias{intcal20} 
 \title{Northern hemisphere 2020 calibration curve} 
 \description{
@@ -17,3 +17,4 @@
 	}
 \references{Reimer P, Austin WEN, Bard E, Bayliss A, Blackwell PG, Bronk Ramsey C, Butzin M, Cheng H, Edwards RL, Friedrich M, Grootes PM, Guilderson TP, Hajdas I, Heaton TJ, Hogg AG, Hughen KA, Kromer B, Manning SW, Muscheler R, Palmer JG, Pearson C, van der Plicht J, Reimer RW, Richards DA, Scott EM, Southon JR, Turney CSM, Wacker L, Adolphi F, Büntgen U, Capano M, Fahrni S, Fogtmann-Schulz A, Friedrich R, Köhler P, Kudsk S, Miyake F, Olsen J, Reinig F, Sakamoto M, Sookdeo A, Talamo S. 2020. The IntCal20 Northern Hemisphere radiocarbon age calibration curve (0-55 cal kBP). Radiocarbon 62. doi: 10.1017/RDC.2020.41.}
 
+\keyword{datasets}

--- a/man/mcmc.Rd
+++ b/man/mcmc.Rd
@@ -57,7 +57,7 @@ cal <- simulateCalendarDates(toy, N)
 age <- uncalibrateCalendarDates(cal, shcal20)
 data <- data.frame(age = age, sd = 50, phase = 1:N, datingType = '14C')
 
-\donttest{
+\dontrun{
 # Calibrate each phase, taking care to restrict to the modelled date range
 CalArray <- makeCalArray(shcal20, calrange = range(toy$year), inc = 5)
 PD <- phaseCalibrator(data, CalArray, remove.external = TRUE)

--- a/man/phaseModel.Rd
+++ b/man/phaseModel.Rd
@@ -38,9 +38,18 @@
 	# specify the prior probabilities of the parameter values of a gaussian model in a matrix
 	mu.range <- c(5500,7000)
 	sigma.range <- c(5,700)
-	prior.matrix <- matrix(1,150,150); prior.matrix <- prior.matrix/sum(prior.matrix)
-	row.names(prior.matrix) <- seq(min(mu.range),max(mu.range),length.out=nrow(prior.matrix))
-	colnames(prior.matrix) <- seq(min(sigma.range),max(sigma.range),length.out=ncol(prior.matrix))
+	prior.matrix <- matrix(1,150,150)
+    prior.matrix <- prior.matrix/sum(prior.matrix)
+    row.names(prior.matrix) <- seq(
+       from = min(mu.range),
+       to = max(mu.range),
+       length.out = nrow(prior.matrix)
+    )
+	colnames(prior.matrix) <- seq(
+           from = min(sigma.range),
+           to = max(sigma.range),
+           length.out=ncol(prior.matrix)
+        )
 
 	# generate the posterior parameter probabilities
 	pm <- phaseModel(data, calcurve, prior.matrix, model='norm', plot=TRUE)

--- a/man/plotCalArray.Rd
+++ b/man/plotCalArray.Rd
@@ -16,6 +16,7 @@
 \examples{
 \donttest{
 	# generate a CalArray of the intcal20 curve covering 5500 calBP to 6000 calBP
+    data(intcal20)
 	x <- makeCalArray( calcurve = intcal20, calrange = c(5500,6000), inc = 1 )
 	plotCalArray(x)
 	}

--- a/man/plotSimulationSummary.Rd
+++ b/man/plotSimulationSummary.Rd
@@ -21,7 +21,7 @@
 	Default NULL for legend.x and legend.y will automatically add a legend, which may not be ideally placed to avoid overlapping other components of the plot. To remove the legend, simply place well outside the boundary.
 	}
 \examples{
-	\donttest{
+	\dontrun{
 	summary <- SPDsimulationTest(data=SAAD, 
 		calcurve=shcal20, 
 		calrange=c(2500,14000), 

--- a/vignettes/guide.Rmd
+++ b/vignettes/guide.Rmd
@@ -11,12 +11,17 @@ output:
   logo: logo.jpg
 vignette: >
   %\VignetteEngine{knitr::rmarkdown}
-  %\VignetteIndexEntry{Guide to using ADMUR}
+  %\VignetteIndexEntry{ADMUR: Ancient Demographic Modelling Using Radiocarbon }
   %\usepackage[utf8]{inputenc}
 ---
+
 <style>
 p.caption {font-size: 0.7em;}
 </style>
+
+```{r setup, include=FALSE}
+options(rmarkdown.html_vignette.check_title = FALSE)
+```
 
 **********
 
@@ -93,7 +98,7 @@ data6[1:10,]
 
 **********
 
-# 2. radiocarbon date calibration and SPDs
+# 2. Radiocarbon date calibration and SPDs
 
 Generating a single calibrated date distribution, or a Summed Probability Distribution (SPD) of several calibrated dates, requires either a two-step process to give the user full control of the date range and temporal resolution, or a simpler one step process using a wrapper function that automatically estimates a sensible date range and resolution from the dataset.
 
@@ -563,7 +568,7 @@ plotPD(spd)
 lines(mod.combo, col=cols[1], lwd=5)
 legend(x=4000, y=max(spd)*1.2,  lwd=5, col=cols[1], bty='n', legend=c('combo.sine.logistic'))
 ```
-![Example of a combination model](combination_model.png){width=680px}  
+![Example of a combination model](combo_models.png){width=680px}  
 
 **********
 

--- a/vignettes/guide.Rmd
+++ b/vignettes/guide.Rmd
@@ -129,6 +129,7 @@ Generating the SPD without the wrapper gives you more control, and requires a tw
 This is useful for improving computational times if generating many SPDs, for example in a simulation framework, since the CalArray needs generating only once. 
 
 ```{r, eval = TRUE, fig.height = 3, fig.width=7, fig.align = "center", dev='jpeg', quality=100, warning=FALSE}
+data(intcal20)
 data <- data.frame( age = c(9144), sd=c(151) )
 CalArray <- makeCalArray( calcurve=intcal20, calrange=c(8000,13000) )
 cal <- summedCalibrator(data, CalArray)


### PR DESCRIPTION
EDIT: This pull requestion correct all warnings and notes resulting from R CMD check

It  also adds two github actions:
1. one that automates the R CMD check on mac/windows/ubuntu (from https://github.com/r-lib/actions/)
2. one that automates the compilation and publication of the vignette on github page (this will need to be fixed after merging) 

----
First version of the PR:

On my debian  12 (full `sessionInfo()` below), this pull request corrects two notes over 3 that  were returned by:

```bash
R CMD build.
R CMD check ADMUR_1.0.3.9005.tar.gz
```
Now the only note left is due to this::

```
* checking R code for possible problems ... NOTE                                                          
summedCalibratorWrapper: no visible binding for global variable                                           
  ‘intcal20’                                         
Undefined global functions or variables:                                                                  
  intcal20                                           
* checking Rd files ... OK   
````

The rest is ok, the pull request also totally remove the examples from the checks ; by using dontrun instead of donttest, which speed up compilation task.
It correct a minor error of filename in `guide.Rmd` and remove the warning on title mismatch buy using R-markdown option: `options(rmarkdown.html_vignette.check_title = FALSE) `

---------
output of sessionInfo():

```
R version 4.2.2 Patched (2022-11-10 r83330)
Platform: x86_64-pc-linux-gnu (64-bit)
Running under: Debian GNU/Linux 12 (bookworm)

Matrix products: default
BLAS:   /usr/lib/x86_64-linux-gnu/blas/libblas.so.3.11.0
LAPACK: /usr/lib/x86_64-linux-gnu/lapack/liblapack.so.3.11.0

locale:
 [1] LC_CTYPE=en_GB.UTF-8       LC_NUMERIC=C              
 [3] LC_TIME=en_GB.UTF-8        LC_COLLATE=en_GB.UTF-8    
 [5] LC_MONETARY=en_GB.UTF-8    LC_MESSAGES=en_GB.UTF-8   
 [7] LC_PAPER=en_GB.UTF-8       LC_NAME=C                 
 [9] LC_ADDRESS=C               LC_TELEPHONE=C            
[11] LC_MEASUREMENT=en_GB.UTF-8 LC_IDENTIFICATION=C       

attached base packages:
[1] stats     graphics  grDevices utils     datasets  methods   base     

loaded via a namespace (and not attached):
[1] compiler_4.2.2
```

This pull request correct a few notes 